### PR TITLE
Add latest dev.to article card to Writing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,6 +775,31 @@
           <div class="projects__grid">
             <article class="project" data-reveal>
               <div class="project__head">
+                <i class="uil uil-newspaper project__icon" aria-hidden="true"></i>
+                <div class="project__links">
+                  <a
+                    href="https://dev.to/hassannaeem/i-built-a-browser-agent-that-plays-a-game-by-looking-at-pixels-3l86"
+                    target="_blank" rel="noopener noreferrer"
+                    aria-label="Read article on dev.to"
+                    ><i class="uil uil-external-link-alt" aria-hidden="true"></i
+                  ></a>
+                </div>
+              </div>
+              <h3>I built a browser agent that plays a game by looking at pixels</h3>
+              <p>
+                Walking through the Python agent I shipped — nested iframe
+                traversal, humanlike mouse drags, and reading a game board
+                by sampling canvas pixels. The same pattern generalizes to
+                Figma, Miro, and any legacy canvas-based internal tool.
+              </p>
+              <div class="project__stack">
+                <span>Article</span><span>Python</span
+                ><span>Playwright</span><span>Agents</span>
+              </div>
+            </article>
+
+            <article class="project" data-reveal>
+              <div class="project__head">
                 <i class="uil uil-brain project__icon" aria-hidden="true"></i>
                 <div class="project__links">
                   <a


### PR DESCRIPTION
Adds a card for the newly published dev.to article to the portfolio's Writing & open source section so it gets top billing above the gists.